### PR TITLE
Remove context argument from the recycler_view adapters #92

### DIFF
--- a/app/src/main/java/org/wikiedufoundation/wikiedudashboard/ui/adapters/ArticlesEditedRecyclerAdapter.kt
+++ b/app/src/main/java/org/wikiedufoundation/wikiedudashboard/ui/adapters/ArticlesEditedRecyclerAdapter.kt
@@ -1,6 +1,5 @@
 package org.wikiedufoundation.wikiedudashboard.ui.adapters
 
-import android.content.Context
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
@@ -11,11 +10,11 @@ import org.wikiedufoundation.wikiedudashboard.R
 import org.wikiedufoundation.wikiedudashboard.ui.coursedetail.articlesedited.data.Article
 import java.util.*
 
-class ArticlesEditedRecyclerAdapter(private val context: Context) : RecyclerView.Adapter<RecyclerView.ViewHolder>() {
+class ArticlesEditedRecyclerAdapter : RecyclerView.Adapter<RecyclerView.ViewHolder>() {
     private var edited: List<Article> = ArrayList()
 
     override fun onCreateViewHolder(viewGroup: ViewGroup, i: Int): RecyclerView.ViewHolder {
-        val view1 = LayoutInflater.from(context).inflate(R.layout.item_rv_articles_edited, viewGroup, false)
+        val view1 = LayoutInflater.from(viewGroup.context).inflate(R.layout.item_rv_articles_edited, viewGroup, false)
         return ArticlesEditedViewHolder(view1)
     }
 

--- a/app/src/main/java/org/wikiedufoundation/wikiedudashboard/ui/adapters/CampaignListRecyclerAdapter.kt
+++ b/app/src/main/java/org/wikiedufoundation/wikiedudashboard/ui/adapters/CampaignListRecyclerAdapter.kt
@@ -1,6 +1,5 @@
 package org.wikiedufoundation.wikiedudashboard.ui.adapters
 
-import android.content.Context
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
@@ -13,13 +12,12 @@ import org.wikiedufoundation.wikiedudashboard.ui.campaign.view.CampaignListFragm
 import java.util.*
 
 class CampaignListRecyclerAdapter internal constructor(
-    private val context: Context,
     private var campaignListFragment: CampaignListFragment
 ) : RecyclerView.Adapter<RecyclerView.ViewHolder>() {
     private var campaigns: List<CampaignListData> = ArrayList()
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): RecyclerView.ViewHolder {
-        return MyDashboardViewHolder(LayoutInflater.from(context).inflate(R.layout.item_rv_campaign_list, parent, false))
+        return MyDashboardViewHolder(LayoutInflater.from(parent.context).inflate(R.layout.item_rv_campaign_list, parent, false))
     }
 
     override fun onBindViewHolder(holder: RecyclerView.ViewHolder, position: Int) {

--- a/app/src/main/java/org/wikiedufoundation/wikiedudashboard/ui/adapters/CategoryListRecyclerAdapter.kt
+++ b/app/src/main/java/org/wikiedufoundation/wikiedudashboard/ui/adapters/CategoryListRecyclerAdapter.kt
@@ -1,6 +1,5 @@
 package org.wikiedufoundation.wikiedudashboard.ui.adapters
 
-import android.content.Context
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
@@ -12,12 +11,14 @@ import org.wikiedufoundation.wikiedudashboard.ui.mediadetail.data.MediaCategory
 import org.wikiedufoundation.wikiedudashboard.ui.mediadetail.view.MediaDetailFragment
 import java.util.*
 
-class CategoryListRecyclerAdapter internal constructor(private val context: Context, private var mediaDetailFragment: MediaDetailFragment) : RecyclerView.Adapter<RecyclerView.ViewHolder>() {
+class CategoryListRecyclerAdapter internal constructor(
+        private var mediaDetailFragment: MediaDetailFragment
+) : RecyclerView.Adapter<RecyclerView.ViewHolder>() {
     private var courses: List<MediaCategory> = ArrayList()
     private var course: MediaCategory? = null
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): RecyclerView.ViewHolder {
-        val view1 = LayoutInflater.from(context).inflate(R.layout.item_rv_media_category, parent, false)
+        val view1 = LayoutInflater.from(parent.context).inflate(R.layout.item_rv_media_category, parent, false)
         return CategoryViewHolder(view1)
     }
 

--- a/app/src/main/java/org/wikiedufoundation/wikiedudashboard/ui/adapters/CourseListRecyclerAdapter.kt
+++ b/app/src/main/java/org/wikiedufoundation/wikiedudashboard/ui/adapters/CourseListRecyclerAdapter.kt
@@ -1,6 +1,5 @@
 package org.wikiedufoundation.wikiedudashboard.ui.adapters
 
-import android.content.Context
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
@@ -10,18 +9,16 @@ import kotlinx.android.synthetic.main.item_rv_explore_courses.view.*
 import org.wikiedufoundation.wikiedudashboard.R
 import org.wikiedufoundation.wikiedudashboard.ui.courselist.view.CourseListFragment
 import org.wikiedufoundation.wikiedudashboard.ui.dashboard.data.CourseListData
-import org.wikiedufoundation.wikiedudashboard.ui.profile.view.ProfileCourseListFragment
 import java.util.*
 
 class CourseListRecyclerAdapter internal constructor(
-    private val context: Context,
     private var courseListFragment: CourseListFragment
 ) : RecyclerView.Adapter<RecyclerView.ViewHolder>() {
 
     private var courses: List<CourseListData> = ArrayList()
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): RecyclerView.ViewHolder {
-        return MyDashboardViewHolder(LayoutInflater.from(context).inflate(R.layout.item_rv_explore_courses, parent, false))
+        return MyDashboardViewHolder(LayoutInflater.from(parent.context).inflate(R.layout.item_rv_explore_courses, parent, false))
     }
 
     override fun onBindViewHolder(holder: RecyclerView.ViewHolder, position: Int) {

--- a/app/src/main/java/org/wikiedufoundation/wikiedudashboard/ui/adapters/CourseUploadsRecyclerAdapter.kt
+++ b/app/src/main/java/org/wikiedufoundation/wikiedudashboard/ui/adapters/CourseUploadsRecyclerAdapter.kt
@@ -15,13 +15,17 @@ import org.wikiedufoundation.wikiedudashboard.ui.coursedetail.uploads.data.Cours
 import org.wikiedufoundation.wikiedudashboard.ui.coursedetail.uploads.view.CourseUploadsFragment
 import java.util.*
 
-class CourseUploadsRecyclerAdapter(private val context: Context, internal var courseUploadsFragment: CourseUploadsFragment) : RecyclerView.Adapter<RecyclerView.ViewHolder>() {
+class CourseUploadsRecyclerAdapter(
+        private var courseUploadsFragment: CourseUploadsFragment
+) : RecyclerView.Adapter<RecyclerView.ViewHolder>() {
+    private lateinit var ctx: Context
     private var courseUploadList: CourseUploadList? = null
     private var courseUploads: List<CourseUpload> = ArrayList()
     private var courseUpload: CourseUpload? = null
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): RecyclerView.ViewHolder {
-        val view1 = LayoutInflater.from(context).inflate(R.layout.item_rv_course_upload, parent, false)
+        ctx = parent.context
+        val view1 = LayoutInflater.from(ctx).inflate(R.layout.item_rv_course_upload, parent, false)
         return MyDashboardViewHolder(view1)
     }
 
@@ -29,7 +33,7 @@ class CourseUploadsRecyclerAdapter(private val context: Context, internal var co
         courseUpload = courseUploads[position]
         val myDashboardViewHolder = holder as MyDashboardViewHolder
         myDashboardViewHolder.tvUploadTitle.text = courseUpload!!.file_name
-        Glide.with(context).load(courseUpload!!.thumbUrl).into(myDashboardViewHolder.ivCourseUpload)
+        Glide.with(ctx).load(courseUpload!!.thumbUrl).into(myDashboardViewHolder.ivCourseUpload)
         holder.itemView.setOnClickListener {
             courseUploadsFragment.openCourseDetail(courseUploadList, position)
         }

--- a/app/src/main/java/org/wikiedufoundation/wikiedudashboard/ui/adapters/FileUsesRecyclerAdapter.kt
+++ b/app/src/main/java/org/wikiedufoundation/wikiedudashboard/ui/adapters/FileUsesRecyclerAdapter.kt
@@ -1,6 +1,5 @@
 package org.wikiedufoundation.wikiedudashboard.ui.adapters
 
-import android.content.Context
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
@@ -12,12 +11,14 @@ import org.wikiedufoundation.wikiedudashboard.ui.mediadetail.data.FileUsage
 import org.wikiedufoundation.wikiedudashboard.ui.mediadetail.view.MediaDetailFragment
 import java.util.*
 
-class FileUsesRecyclerAdapter internal constructor(private val context: Context, private var mediaDetailFragment: MediaDetailFragment) : RecyclerView.Adapter<RecyclerView.ViewHolder>() {
+class FileUsesRecyclerAdapter internal constructor(
+        private var mediaDetailFragment: MediaDetailFragment
+) : RecyclerView.Adapter<RecyclerView.ViewHolder>() {
     private var courses: List<FileUsage> = ArrayList()
     private var course: FileUsage? = null
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): RecyclerView.ViewHolder {
-        val view1 = LayoutInflater.from(context).inflate(R.layout.item_rv_media_category, parent, false)
+        val view1 = LayoutInflater.from(parent.context).inflate(R.layout.item_rv_media_category, parent, false)
         return CategoryViewHolder(view1)
     }
 

--- a/app/src/main/java/org/wikiedufoundation/wikiedudashboard/ui/adapters/MyDashboardRecyclerAdapter.kt
+++ b/app/src/main/java/org/wikiedufoundation/wikiedudashboard/ui/adapters/MyDashboardRecyclerAdapter.kt
@@ -1,6 +1,5 @@
 package org.wikiedufoundation.wikiedudashboard.ui.adapters
 
-import android.content.Context
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
@@ -12,13 +11,14 @@ import org.wikiedufoundation.wikiedudashboard.ui.dashboard.data.CourseListData
 import org.wikiedufoundation.wikiedudashboard.ui.dashboard.view.MyDashboardFragment
 import java.util.*
 
-class MyDashboardRecyclerAdapter internal constructor(private val context: Context,
-                          internal var myDashboardFragment: MyDashboardFragment) : RecyclerView.Adapter<RecyclerView.ViewHolder>() {
+class MyDashboardRecyclerAdapter internal constructor(
+        private var myDashboardFragment: MyDashboardFragment
+) : RecyclerView.Adapter<RecyclerView.ViewHolder>() {
     private var courses: List<CourseListData> = ArrayList()
     private var course: CourseListData? = null
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): RecyclerView.ViewHolder {
-        val view1 = LayoutInflater.from(context).inflate(R.layout.item_rv_my_dashboard, parent, false)
+        val view1 = LayoutInflater.from(parent.context).inflate(R.layout.item_rv_my_dashboard, parent, false)
         return MyDashboardViewHolder(view1)
     }
 

--- a/app/src/main/java/org/wikiedufoundation/wikiedudashboard/ui/adapters/ProfileCourseListRecyclerAdapter.kt
+++ b/app/src/main/java/org/wikiedufoundation/wikiedudashboard/ui/adapters/ProfileCourseListRecyclerAdapter.kt
@@ -1,6 +1,5 @@
 package org.wikiedufoundation.wikiedudashboard.ui.adapters
 
-import android.content.Context
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
@@ -8,21 +7,18 @@ import android.widget.TextView
 import androidx.recyclerview.widget.RecyclerView
 import kotlinx.android.synthetic.main.item_rv_explore_courses.view.*
 import org.wikiedufoundation.wikiedudashboard.R
-import org.wikiedufoundation.wikiedudashboard.ui.courselist.view.CourseListFragment
-import org.wikiedufoundation.wikiedudashboard.ui.dashboard.data.CourseListData
 import org.wikiedufoundation.wikiedudashboard.ui.profile.data.CourseData
 import org.wikiedufoundation.wikiedudashboard.ui.profile.view.ProfileCourseListFragment
 import java.util.*
 
 class ProfileCourseListRecyclerAdapter internal constructor(
-    private val context: Context,
-    private var profileCourseListFragment: ProfileCourseListFragment
+        private var profileCourseListFragment: ProfileCourseListFragment
 ) : RecyclerView.Adapter<RecyclerView.ViewHolder>() {
 
     private var courses: List<CourseData> = ArrayList()
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): RecyclerView.ViewHolder {
-        return MyDashboardViewHolder(LayoutInflater.from(context).inflate(R.layout.item_rv_explore_courses, parent, false))
+        return MyDashboardViewHolder(LayoutInflater.from(parent.context).inflate(R.layout.item_rv_explore_courses, parent, false))
     }
 
     override fun onBindViewHolder(holder: RecyclerView.ViewHolder, position: Int) {

--- a/app/src/main/java/org/wikiedufoundation/wikiedudashboard/ui/adapters/RecentActivityRecyclerAdapter.kt
+++ b/app/src/main/java/org/wikiedufoundation/wikiedudashboard/ui/adapters/RecentActivityRecyclerAdapter.kt
@@ -14,11 +14,13 @@ import java.text.SimpleDateFormat
 import java.util.*
 
 
-class RecentActivityRecyclerAdapter(private val context: Context) : RecyclerView.Adapter<RecyclerView.ViewHolder>() {
+class RecentActivityRecyclerAdapter : RecyclerView.Adapter<RecyclerView.ViewHolder>() {
+    private lateinit var ctx: Context
     private var activities: List<RecentActivity> = ArrayList()
 
     override fun onCreateViewHolder(viewGroup: ViewGroup, i: Int): RecyclerView.ViewHolder {
-        val view1 = LayoutInflater.from(context).inflate(R.layout.item_rv_recent_activity, viewGroup, false)
+        ctx = viewGroup.context
+        val view1 = LayoutInflater.from(ctx).inflate(R.layout.item_rv_recent_activity, viewGroup, false)
         return ArticlesEditedViewHolder(view1)
     }
 
@@ -29,7 +31,7 @@ class RecentActivityRecyclerAdapter(private val context: Context) : RecyclerView
         articlesEditedViewHolder.tvCountCharactersAdded.text = activities[i].characters.toString()
         articlesEditedViewHolder.tvRevisor.text = activities[i].revisor
 
-        val dateFormat = SimpleDateFormat(context.getString(R.string.time_format_12_hours))
+        val dateFormat = SimpleDateFormat(ctx.getString(R.string.time_format_12_hours))
         val formattedDate = dateFormat.format(activities[i].date).toString()
 
         articlesEditedViewHolder.tvDate.text = formattedDate

--- a/app/src/main/java/org/wikiedufoundation/wikiedudashboard/ui/adapters/StudentListRecyclerAdapter.kt
+++ b/app/src/main/java/org/wikiedufoundation/wikiedudashboard/ui/adapters/StudentListRecyclerAdapter.kt
@@ -1,25 +1,23 @@
 package org.wikiedufoundation.wikiedudashboard.ui.adapters
 
-import android.content.Context
-import android.content.Intent
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.widget.TextView
-import androidx.core.content.ContextCompat
 import androidx.recyclerview.widget.RecyclerView
 import kotlinx.android.synthetic.main.item_rv_students.view.*
 import org.wikiedufoundation.wikiedudashboard.R
 import org.wikiedufoundation.wikiedudashboard.ui.coursedetail.students.data.User
 import org.wikiedufoundation.wikiedudashboard.ui.coursedetail.students.view.StudentListFragment
-import org.wikiedufoundation.wikiedudashboard.ui.mediadetail.MediaDetailsActivity
 import java.util.*
 
-class StudentListRecyclerAdapter(private val context: Context, internal var studentListFragment: StudentListFragment) : RecyclerView.Adapter<StudentListRecyclerAdapter.MyAdapter>() {
+class StudentListRecyclerAdapter(
+        private var studentListFragment: StudentListFragment
+) : RecyclerView.Adapter<StudentListRecyclerAdapter.MyAdapter>() {
     private var studentList: List<User> = ArrayList()
 
     override fun onCreateViewHolder(viewGroup: ViewGroup, i: Int): MyAdapter {
-        val view = LayoutInflater.from(context).inflate(R.layout.item_rv_students, viewGroup, false)
+        val view = LayoutInflater.from(viewGroup.context).inflate(R.layout.item_rv_students, viewGroup, false)
 
         return MyAdapter(view)
     }

--- a/app/src/main/java/org/wikiedufoundation/wikiedudashboard/ui/campaign/view/CampaignListFragment.kt
+++ b/app/src/main/java/org/wikiedufoundation/wikiedudashboard/ui/campaign/view/CampaignListFragment.kt
@@ -63,7 +63,7 @@ class CampaignListFragment : Fragment(), CampaignListContract.View {
         val context: Context? = context
         sharedPrefs = SharedPrefs(context)
         campaignListPresenter = CampaignListPresenterImpl(this, RetrofitCampaignListProvider())
-        campaignListRecyclerAdapter = CampaignListRecyclerAdapter(context!!, this)
+        campaignListRecyclerAdapter = CampaignListRecyclerAdapter(this)
         val linearLayoutManager = LinearLayoutManager(context)
         recyclerView!!.layoutManager = linearLayoutManager
         recyclerView!!.setHasFixedSize(true)

--- a/app/src/main/java/org/wikiedufoundation/wikiedudashboard/ui/coursedetail/articlesedited/view/CourseArticlesEditedFragment.kt
+++ b/app/src/main/java/org/wikiedufoundation/wikiedudashboard/ui/coursedetail/articlesedited/view/CourseArticlesEditedFragment.kt
@@ -39,7 +39,7 @@ class CourseArticlesEditedFragment : Fragment(), ArticlesEditedView {
 
         articlesEditedPresenter = ArticlesEditedPresenterImpl(RetrofitArticlesEditedProvider(), this)
 
-        articlesEditedRecyclerAdapter = ArticlesEditedRecyclerAdapter(context!!)
+        articlesEditedRecyclerAdapter = ArticlesEditedRecyclerAdapter()
         val linearLayoutManager = LinearLayoutManager(context)
         recyclerView?.layoutManager = linearLayoutManager
         recyclerView?.setHasFixedSize(true)

--- a/app/src/main/java/org/wikiedufoundation/wikiedudashboard/ui/coursedetail/recentactivity/RecentActivityFragment.kt
+++ b/app/src/main/java/org/wikiedufoundation/wikiedudashboard/ui/coursedetail/recentactivity/RecentActivityFragment.kt
@@ -40,7 +40,7 @@ class RecentActivityFragment : Fragment(), RecentActivityContract.View {
 
         recentActivityPresenter = RecentActivityPresenterImpl(this, RetrofitRecentActivityProvider())
 
-        recentActivityRecyclerAdapter = RecentActivityRecyclerAdapter(context!!)
+        recentActivityRecyclerAdapter = RecentActivityRecyclerAdapter()
         val linearLayoutManager = LinearLayoutManager(context)
         recyclerView!!.layoutManager = linearLayoutManager
         recyclerView!!.setHasFixedSize(true)

--- a/app/src/main/java/org/wikiedufoundation/wikiedudashboard/ui/coursedetail/students/view/StudentListFragment.kt
+++ b/app/src/main/java/org/wikiedufoundation/wikiedudashboard/ui/coursedetail/students/view/StudentListFragment.kt
@@ -44,7 +44,7 @@ class StudentListFragment : Fragment(), StudentListView {
         layoutManager = LinearLayoutManager(context)
         recyclerView!!.layoutManager = layoutManager
         recyclerView!!.setHasFixedSize(true)
-        studentListRecyclerAdapter = StudentListRecyclerAdapter(context!!, this)
+        studentListRecyclerAdapter = StudentListRecyclerAdapter(this)
         recyclerView!!.adapter = studentListRecyclerAdapter
         studentListPresenter!!.requestStudentList(url!!)
 

--- a/app/src/main/java/org/wikiedufoundation/wikiedudashboard/ui/coursedetail/uploads/view/CourseUploadsFragment.kt
+++ b/app/src/main/java/org/wikiedufoundation/wikiedudashboard/ui/coursedetail/uploads/view/CourseUploadsFragment.kt
@@ -60,7 +60,7 @@ class CourseUploadsFragment : Fragment(), CourseUploadsView {
         tvNoStudents = view.findViewById(R.id.tv_no_uploads)
 
         courseUploadsPresenter = CourseUploadsPresenterImpl(this, RetrofitCourseUploadsProvider())
-        courseUploadsRecyclerAdapter = CourseUploadsRecyclerAdapter(context!!, this)
+        courseUploadsRecyclerAdapter = CourseUploadsRecyclerAdapter(this)
         val linearLayoutManager = LinearLayoutManager(context)
         recyclerView!!.layoutManager = linearLayoutManager
         recyclerView!!.setHasFixedSize(true)

--- a/app/src/main/java/org/wikiedufoundation/wikiedudashboard/ui/courselist/view/CourseListFragment.kt
+++ b/app/src/main/java/org/wikiedufoundation/wikiedudashboard/ui/courselist/view/CourseListFragment.kt
@@ -62,7 +62,7 @@ class CourseListFragment : Fragment(), CourseListView {
         val sharedPrefs: SharedPrefs? = SharedPrefs(context)
         tv_no_courses!!.text = sharedPrefs!!.cookies
         courseListPresenter = CourseListPresenterImpl(this, RetrofitCourseListProvider())
-        courseListRecyclerAdapter = CourseListRecyclerAdapter(context!!, this)
+        courseListRecyclerAdapter = CourseListRecyclerAdapter(this)
         val linearLayoutManager = LinearLayoutManager(context)
         recyclerView!!.layoutManager = linearLayoutManager
         recyclerView!!.setHasFixedSize(true)

--- a/app/src/main/java/org/wikiedufoundation/wikiedudashboard/ui/dashboard/view/MyDashboardFragment.kt
+++ b/app/src/main/java/org/wikiedufoundation/wikiedudashboard/ui/dashboard/view/MyDashboardFragment.kt
@@ -67,7 +67,7 @@ class MyDashboardFragment : Fragment(), MyDashboardContract.View {
         val context: Context? = context
         sharedPrefs = SharedPrefs(context)
         myDashboardPresenter = MyDashboardPresenterImpl(this, RetrofitMyDashboardProvider())
-        myDashboardRecyclerAdapter = MyDashboardRecyclerAdapter(context!!, this)
+        myDashboardRecyclerAdapter = MyDashboardRecyclerAdapter(this)
         val linearLayoutManager = LinearLayoutManager(context)
         recyclerView!!.layoutManager = linearLayoutManager
         recyclerView!!.setHasFixedSize(true)

--- a/app/src/main/java/org/wikiedufoundation/wikiedudashboard/ui/mediadetail/view/MediaDetailFragment.kt
+++ b/app/src/main/java/org/wikiedufoundation/wikiedudashboard/ui/mediadetail/view/MediaDetailFragment.kt
@@ -116,13 +116,13 @@ class MediaDetailFragment : Fragment(), Toolbar.OnMenuItemClickListener, MediaDe
         toolbar!!.setOnMenuItemClickListener(this)
 
         mediaDetailsPresenter = MediaDetailsPresenterImpl(this, RetrofitMediaDetailsProvider())
-        categoryListRecyclerAdapter = CategoryListRecyclerAdapter(context, this)
+        categoryListRecyclerAdapter = CategoryListRecyclerAdapter(this)
         val linearLayoutManager = LinearLayoutManager(context)
         categoriesRecyclerView!!.layoutManager = linearLayoutManager
         categoriesRecyclerView!!.setHasFixedSize(true)
         categoriesRecyclerView!!.adapter = categoryListRecyclerAdapter
 
-        fileusesRecyclerAdapter = FileUsesRecyclerAdapter(context, this)
+        fileusesRecyclerAdapter = FileUsesRecyclerAdapter(this)
         val linearLayoutManager2 = LinearLayoutManager(context)
         fileUsesRecyclerView!!.layoutManager = linearLayoutManager2
         fileUsesRecyclerView!!.setHasFixedSize(true)

--- a/app/src/main/java/org/wikiedufoundation/wikiedudashboard/ui/profile/view/ProfileCourseListFragment.kt
+++ b/app/src/main/java/org/wikiedufoundation/wikiedudashboard/ui/profile/view/ProfileCourseListFragment.kt
@@ -56,7 +56,7 @@ class ProfileCourseListFragment : Fragment() {
         val context: Context? = context
         val sharedPrefs: SharedPrefs? = SharedPrefs(context)
         tv_no_courses!!.text = sharedPrefs!!.cookies
-        courseListRecyclerAdapter = ProfileCourseListRecyclerAdapter(context!!, this)
+        courseListRecyclerAdapter = ProfileCourseListRecyclerAdapter(this)
         val linearLayoutManager = LinearLayoutManager(context)
         recyclerView!!.layoutManager = linearLayoutManager
         recyclerView!!.setHasFixedSize(true)


### PR DESCRIPTION
Fixes #92 

removed the `context` argument from the `recycler view adapter`. and now the `adapter` uses the viewGroup context.