### PR TITLE
Fixes #52 Can't login

### DIFF
--- a/app/src/main/java/org/wikiedufoundation/wikiedudashboard/ui/welcome/WikiEducationDashboardFragment.kt
+++ b/app/src/main/java/org/wikiedufoundation/wikiedudashboard/ui/welcome/WikiEducationDashboardFragment.kt
@@ -73,7 +73,7 @@ class WikiEducationDashboardFragment : Fragment() {
      *  the additional account set-up screens displayed after the
      *  user clicks on the OAuth screen "Allow" button
      */
-        webView!!.getSettings().setJavaScriptEnabled(true)
+        webView?.getSettings()?.setJavaScriptEnabled(true)
         webView!!.webViewClient = object : WebViewClient() {
             override fun onPageStarted(view: WebView, url: String, favicon: Bitmap?) {
                 super.onPageStarted(view, url, favicon)

--- a/app/src/main/java/org/wikiedufoundation/wikiedudashboard/ui/welcome/WikiEducationDashboardFragment.kt
+++ b/app/src/main/java/org/wikiedufoundation/wikiedudashboard/ui/welcome/WikiEducationDashboardFragment.kt
@@ -68,7 +68,12 @@ class WikiEducationDashboardFragment : Fragment() {
         return view
     }
 
-    private fun setWebView() {
+    private fun setWebView() { /** Enable JavaScript execution to display all web page content.
+     *  This enables users logging in for the first time to complete
+     *  the additional account set-up screens displayed after the
+     *  user clicks on the OAuth screen "Allow" button
+     */
+        webView!!.getSettings().setJavaScriptEnabled(true)
         webView!!.webViewClient = object : WebViewClient() {
             override fun onPageStarted(view: WebView, url: String, favicon: Bitmap?) {
                 super.onPageStarted(view, url, favicon)


### PR DESCRIPTION
## What this PR does
The issue occurs only the first time a user logs in using Wikipedia.  I have recreated the issue on emulators running APIs 19-27 and on a Samsung Galaxy running API 28.  After the user clicks the "Allow" button on the OAuth screen, the website takes them through several additional screens to complete their account setup.  The screenshot Sam Walton provided when he submitted the issue shows the partial content of the first of these additional screens.

To fix the issue I've enabled JavaScript in the WebView to display all of the web page content. 

## Open questions and concerns
 I've tested this on the mix of emulators and actual phone mentioned above and found that it works for APIs 24-28, but not on the emulators running APIs 19-23, which is odd given that setJavaScriptEnabled was added in API 1.  It may simply be an emulator issue and I have no actual devices to use to test APIs 19-23.  

