### PR TITLE
Addresses #96 App Crashed At Launching

### DIFF
--- a/app/src/main/java/org/wikiedufoundation/wikiedudashboard/ui/welcome/OutreachProgramsDashboardFragment.kt
+++ b/app/src/main/java/org/wikiedufoundation/wikiedudashboard/ui/welcome/OutreachProgramsDashboardFragment.kt
@@ -69,6 +69,12 @@ class OutreachProgramsDashboardFragment : Fragment() {
     }
 
     private fun setWebView() {
+        /** Enable JavaScript execution to display all web page content.
+         *  This enables users logging in for the first time to complete
+         *  the additional account set-up screens displayed after the
+         *  user clicks on the OAuth screen "Allow" button
+         */
+        webView?.getSettings()?.setJavaScriptEnabled(true)
         webView!!.webViewClient = object : WebViewClient() {
             override fun onPageStarted(view: WebView, url: String, favicon: Bitmap?) {
                 super.onPageStarted(view, url, favicon)

--- a/app/src/main/java/org/wikiedufoundation/wikiedudashboard/ui/welcome/WikiEducationDashboardFragment.kt
+++ b/app/src/main/java/org/wikiedufoundation/wikiedudashboard/ui/welcome/WikiEducationDashboardFragment.kt
@@ -73,7 +73,7 @@ class WikiEducationDashboardFragment : Fragment() {
      *  the additional account set-up screens displayed after the
      *  user clicks on the OAuth screen "Allow" button
      */
-        webView!!.getSettings().setJavaScriptEnabled(true)
+        webView?.getSettings()?.setJavaScriptEnabled(true)
         webView!!.webViewClient = object : WebViewClient() {
             override fun onPageStarted(view: WebView, url: String, favicon: Bitmap?) {
                 super.onPageStarted(view, url, favicon)

--- a/app/src/main/java/org/wikiedufoundation/wikiedudashboard/ui/welcome/WikiEducationDashboardFragment.kt
+++ b/app/src/main/java/org/wikiedufoundation/wikiedudashboard/ui/welcome/WikiEducationDashboardFragment.kt
@@ -68,7 +68,12 @@ class WikiEducationDashboardFragment : Fragment() {
         return view
     }
 
-    private fun setWebView() {
+    private fun setWebView() { /** Enable JavaScript execution to display all web page content.
+     *  This enables users logging in for the first time to complete
+     *  the additional account set-up screens displayed after the
+     *  user clicks on the OAuth screen "Allow" button
+     */
+        webView!!.getSettings().setJavaScriptEnabled(true)
         webView!!.webViewClient = object : WebViewClient() {
             override fun onPageStarted(view: WebView, url: String, favicon: Bitmap?) {
                 super.onPageStarted(view, url, favicon)


### PR DESCRIPTION
## What this PR does
This issue occurs when the user first logs in to the Outreach Programs and Events Dashboard using Wikipedia.  After the user clicks the "Allow" button on the OAuth screen, the following web page is only partially shown.  I've enabled JavaScript in the WebView to display all of the web page content.

