### PR TITLE
#127 Profile Fragment Crash Due to NullPointerException 

### DIFF
--- a/app/src/main/java/org/wikiedufoundation/wikiedudashboard/ui/profile/data/ProfileDetailsResponse.kt
+++ b/app/src/main/java/org/wikiedufoundation/wikiedudashboard/ui/profile/data/ProfileDetailsResponse.kt
@@ -7,7 +7,7 @@ import com.google.gson.annotations.SerializedName
  * @constructor primary constructor to initialize properties and variables
  * ***/
 class ProfileDetailsResponse (
-        val userProfile: ProfileDetails
+        val userProfile: ProfileDetails?
 )
 
 /**

--- a/app/src/main/java/org/wikiedufoundation/wikiedudashboard/ui/profile/view/ProfileFragment.kt
+++ b/app/src/main/java/org/wikiedufoundation/wikiedudashboard/ui/profile/view/ProfileFragment.kt
@@ -148,9 +148,9 @@ class ProfileFragment : Fragment(), ProfileContract.View, Toolbar.OnMenuItemClic
     @Suppress("UselessCallOnNotNull")
     override fun setProfileData(data: ProfileDetailsResponse) {
         llProfileParent?.visibility = VISIBLE
-        val profilePicUrl = Urls.BASE_URL + data.userProfile.profileImage
+        val profilePicUrl = Urls.BASE_URL + data.userProfile?.profileImage
         Timber.d(profilePicUrl)
-        if (data.userProfile.profileImage.isNullOrEmpty()) {
+        if (data.userProfile?.profileImage.isNullOrEmpty()) {
             ivProfilePic?.setImageDrawable(context?.let { ContextCompat.getDrawable(it, R.drawable.ic_account_circle_white_48dp) })
         } else {
             Glide.with(context).load(profilePicUrl).apply(RequestOptions().circleCrop()).into(ivProfilePic)
@@ -161,11 +161,9 @@ class ProfileFragment : Fragment(), ProfileContract.View, Toolbar.OnMenuItemClic
 //        } else {
         llEmail?.visibility = INVISIBLE
 //        }
-        data.userProfile.bio.let {
-            tvDescription?.text = data.userProfile.bio
-        }
-        tvDescription?.text = data.userProfile.bio
-        tvLocation?.text = data.userProfile.location
+        data.userProfile?.bio.let { tvDescription?.text = it }
+        tvDescription?.text = data.userProfile?.bio
+        tvLocation?.text = data.userProfile?.location
 //        if (data.user_profile.institution!=null) {
 //            tvInstitute?.text = data.user_profile.institution
 //        } else{


### PR DESCRIPTION
The property `ProfileDetails` inside `ProfileDetailsResponse` shouldn't be `optional`. So when the user had any details it would work properly. Alghough for those who hasn't the `response` is `null`. Just make it `optional` and make the proper changes where it is used.