### PR TITLE
chore: Change the fragment_explore_students layout to constraint layout

### DIFF
--- a/app/src/main/res/layout/fragment_explore_students.xml
+++ b/app/src/main/res/layout/fragment_explore_students.xml
@@ -1,30 +1,40 @@
 <?xml version="1.0" encoding="utf-8"?>
-<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.constraintlayout.widget.ConstraintLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     tools:context=".ui.home.ExploreFragment">
-    <androidx.recyclerview.widget.RecyclerView
-        android:id="@+id/rv_students_list"
 
-        android:layout_width="match_parent"
-        android:layout_height="match_parent">
-
-    </androidx.recyclerview.widget.RecyclerView>
-    <TextView
-        android:id="@+id/tv_no_students"
-        android:layout_centerInParent="true"
-        android:gravity="center"
-        android:visibility="gone"
+    <androidx.cardview.widget.CardView
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        android:text="@string/tv_no_users" />
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent">
 
-    <ProgressBar
-        android:id="@+id/progressBar"
-        android:layout_centerInParent="true"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        />
+        <ProgressBar
+            android:id="@+id/progressBar"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_centerInParent="true"
+            android:layout_gravity="center" />
 
-</RelativeLayout>
+        <TextView
+            android:id="@+id/tv_no_students"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:layout_centerInParent="true"
+            android:gravity="center"
+            android:text="@string/tv_no_users"
+            android:visibility="gone" />
+
+        <androidx.recyclerview.widget.RecyclerView
+            android:id="@+id/rv_students_list"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent" />
+
+    </androidx.cardview.widget.CardView>
+</androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
## What this PR does
Fixes issue #143 

## Screenshots
Before:
![Before](https://user-images.githubusercontent.com/29807085/67505775-cc491100-f683-11e9-8958-d5d1a3378540.png)


After:
![After](https://user-images.githubusercontent.com/29807085/67505798-d408b580-f683-11e9-9ac6-0523683603f3.png)

## Open questions and concerns
I noticed that the tabs in the `Explore` layout of the BottomNavigation View doesn't show the tab titles. I had to guess and swipe to access the second tab of the `Explore` layout which in my opinion isn't very ideal.
