### PR TITLE
Resolve #254

### DIFF
--- a/app/src/main/java/org/wikiedufoundation/wikiedudashboard/ui/courselist/presenter/CourseListPresenterImpl.kt
+++ b/app/src/main/java/org/wikiedufoundation/wikiedudashboard/ui/courselist/presenter/CourseListPresenterImpl.kt
@@ -31,6 +31,9 @@ class CourseListPresenterImpl(
             override fun onFailure() {
                 courseListView.showProgressBar(false)
                 courseListView.showMessage("Unable to connect to server.")
+
+                val unknownExploreCoursesResponse = ExploreCoursesResponse(ArrayList())
+                courseListView.setData(unknownExploreCoursesResponse)
             }
         })
     }

--- a/app/src/main/java/org/wikiedufoundation/wikiedudashboard/ui/courselist/view/CourseListFragment.kt
+++ b/app/src/main/java/org/wikiedufoundation/wikiedudashboard/ui/courselist/view/CourseListFragment.kt
@@ -57,8 +57,6 @@ class CourseListFragment : Fragment(), CourseListView {
     ): View? = inflater.inflate(R.layout.fragment_explore_course_list, container, false)
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
-        textViewNoCourses?.text = sharedPrefs.cookies
-
         courseListRecyclerAdapter = CourseListRecyclerAdapter(R.layout.item_rv_explore_courses) {
             openCourseDetail(it)
         }

--- a/app/src/main/java/org/wikiedufoundation/wikiedudashboard/ui/dashboard/MyDashboardPresenterImpl.kt
+++ b/app/src/main/java/org/wikiedufoundation/wikiedudashboard/ui/dashboard/MyDashboardPresenterImpl.kt
@@ -1,6 +1,7 @@
 package org.wikiedufoundation.wikiedudashboard.ui.dashboard
 
 import org.wikiedufoundation.wikiedudashboard.ui.dashboard.data.MyDashboardResponse
+import org.wikiedufoundation.wikiedudashboard.ui.dashboard.data.UserData
 import org.wikiedufoundation.wikiedudashboard.util.PresenterCallback
 import timber.log.Timber
 
@@ -29,6 +30,12 @@ class MyDashboardPresenterImpl(
             override fun onFailure() {
                 myDashboardView.showProgressBar(false)
                 myDashboardView.showMessage("Unable to connect to server.")
+
+                val unknownDashboardResponse =
+                        MyDashboardResponse(
+                                UserData(""), ArrayList()
+                        )
+                myDashboardView.setData(unknownDashboardResponse)
             }
         })
     }

--- a/app/src/main/java/org/wikiedufoundation/wikiedudashboard/ui/profile/view/ProfileCourseListFragment.kt
+++ b/app/src/main/java/org/wikiedufoundation/wikiedudashboard/ui/profile/view/ProfileCourseListFragment.kt
@@ -42,9 +42,6 @@ class ProfileCourseListFragment : Fragment() {
     ): View? = inflater.inflate(R.layout.fragment_explore_course_list, container, false)
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
-        val sharedPrefs: SharedPrefs? = context?.let { SharedPrefs(it) }
-
-        textViewNoCourses?.text = sharedPrefs?.cookies
         courseListRecyclerAdapter = ProfileCourseListRecyclerAdapter(R.layout.item_rv_explore_courses_users) {
             openCourseDetail(it)
         }

--- a/app/src/main/res/layout/fragment_explore_course_list.xml
+++ b/app/src/main/res/layout/fragment_explore_course_list.xml
@@ -25,7 +25,7 @@
         android:layout_centerHorizontal="true"
         android:layout_centerVertical="true"
         android:gravity="center"
-        android:text="@string/hello_blank_fragment"
+        android:text="@string/tv_no_courses"
         android:visibility="gone"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintLeft_toLeftOf="parent"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -48,6 +48,7 @@
     <string name="btn_join">Join</string>
     <string name="btn_cancel">Cancel</string>
     <string name="tv_no_campaigns">No Active Campaigns</string>
+    <string name="tv_no_courses">No Active Courses</string>
     <string name="tv_no_activity">No Activity</string>
     <string name="demo_course_name">Anti-rape movement</string>
     <string name="label_chars_added">Chars Added : </string>
@@ -58,7 +59,7 @@
     <string name="references_added">References Added</string>
     <string name="outreach_programs_and_events_dashboard">Outreach Programs and Events Dashboard</string>
     <string name="menu_settings">Settings</string>
-    <string name="not_enrolled">You are not enrolled in any course</string>
+    <string name="not_enrolled">Not enrolled in any course</string>
     <string name="total_edits">Total Edits</string>
     <string name="media_detail_desc">Description of the media goes here. This can potentially be fairly long, and will need to wrap across multiple lines. We hope it looks nice though.</string>
     <string name="screen1_title">Wiki Education Dashboard</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -59,7 +59,7 @@
     <string name="references_added">References Added</string>
     <string name="outreach_programs_and_events_dashboard">Outreach Programs and Events Dashboard</string>
     <string name="menu_settings">Settings</string>
-    <string name="not_enrolled">Not enrolled in any course</string>
+    <string name="not_enrolled">You are not enrolled in any course</string>
     <string name="total_edits">Total Edits</string>
     <string name="media_detail_desc">Description of the media goes here. This can potentially be fairly long, and will need to wrap across multiple lines. We hope it looks nice though.</string>
     <string name="screen1_title">Wiki Education Dashboard</string>


### PR DESCRIPTION
## What this PR does
This is a resolve for issue #254. Added placeholders for empty screens and modified some already existing placeholders.

Full changes list:

- In fragment "MyDashboardFragment" now can be show a TextView with id "textViewNoCourses" if user haven't joined a program or have happen an error in API.
- Created `@string/tv_no_courses` which appears when was happen a failure in loading courses data or courses list is empty.
- Content of a TextView with id "textViewNoCourses" in `fragment_explore_course_list.xml` was changed from `@string/hello_blank_fragment` to `@string/tv_no_courses`.
- Deleted a cookie text for TextView with id "textViewNoCourses" in fragments `CourseListFragment` and `ProfileCourseListFragment`.
- Modified `@string/not_entolled` from "You are not enrolled in any course" to "Not enrolled in any course".

## Screenshots
Before:
![Before 01](https://drive.google.com/uc?id=1dqn3G4cnDO0B95VArQU8oxHwrlIn7ep0)
![Before 02](https://drive.google.com/uc?id=1SapnVH1l7TQ35CPhTe7rQyi8YSWREcFa)
![Before 03](https://drive.google.com/uc?id=1u32tSifblDpOoCpasM3EL8urJRLKAdxc)
![Before 03 (1)](https://drive.google.com/uc?id=1NWgwAoIJw8iu024wKbWQu-49LCp9j0e6)
![Before 04](https://drive.google.com/uc?id=1fDQ3ez8ZAipU5OKLk3raSdIj1a8Wo2Up)

After:
![After 01](https://drive.google.com/uc?id=1lN_PlFLUqBro_aVpop6o4dZF2Yn2F18a)
![After 02-03](https://drive.google.com/uc?id=1OTEzqppqWQ4HqTqs9rSs2pKTfWYgXTqz)
![After 03 (1)](https://drive.google.com/uc?id=1MdmqFrwgWm-ko39yns9vYw3_XQUOlUuR)
![After 04](https://drive.google.com/uc?id=1O6rUkq-fV5AuEKCq51jQv8aSLmKAABDx)