### PR TITLE
Campaign details home tab

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -48,6 +48,11 @@ android {
 
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
+    implementation 'androidx.appcompat:appcompat:1.0.2'
+    implementation 'androidx.constraintlayout:constraintlayout:1.1.3'
+    implementation 'androidx.legacy:legacy-support-v4:1.0.0'
+    implementation 'androidx.lifecycle:lifecycle-extensions:2.0.0'
+    implementation 'androidx.lifecycle:lifecycle-viewmodel-ktx:2.0.0'
     testImplementation 'androidx.test:core:1.2.0'
     testImplementation "org.robolectric:robolectric:4.3.1"
     implementation Deps.constraintLayoutVersion

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -3,8 +3,11 @@
     xmlns:tools="http://schemas.android.com/tools"
     package="org.wikiedufoundation.wikiedudashboard">
 
-    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" tools:node="replace"/>
-    <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE"/>
+    <uses-permission
+        android:name="android.permission.WRITE_EXTERNAL_STORAGE"
+        tools:node="replace" />
+    <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
+    <uses-permission android:name="android.permission.INTERNET" />
 
     <application
         android:name=".App"
@@ -15,7 +18,8 @@
         android:supportsRtl="true"
         android:theme="@style/AppTheme"
         tools:ignore="GoogleAppIndexingWarning">
-        <activity android:name=".ui.welcome.WelcomeActivity"></activity>
+        <activity android:name=".ui.campaigndetails.home.view.CampaignDetailsHomeActivity"></activity>
+        <activity android:name=".ui.welcome.WelcomeActivity" />
         <activity android:name=".ui.welcome.onboarding.WelcomeHostActivity" />
         <activity android:name=".ui.splash.SplashActivity">
             <intent-filter>
@@ -44,7 +48,5 @@
             android:name=".ui.home.HomeActivity"
             android:label="@string/app_name" />
     </application>
-
-    <uses-permission android:name="android.permission.INTERNET" />
 
 </manifest>

--- a/app/src/main/java/org/wikiedufoundation/wikiedudashboard/data/network/WikiEduDashboardApi.kt
+++ b/app/src/main/java/org/wikiedufoundation/wikiedudashboard/data/network/WikiEduDashboardApi.kt
@@ -1,6 +1,7 @@
 package org.wikiedufoundation.wikiedudashboard.data.network
 
 import org.wikiedufoundation.wikiedudashboard.ui.campaign.data.ExploreCampaignsResponse
+import org.wikiedufoundation.wikiedudashboard.ui.campaigndetails.home.data.CampaignDetailsResponse
 import org.wikiedufoundation.wikiedudashboard.ui.coursedetail.articlesedited.data.ArticlesEdited
 import org.wikiedufoundation.wikiedudashboard.ui.coursedetail.common.data.CourseDetailResponse
 import org.wikiedufoundation.wikiedudashboard.ui.coursedetail.recentactivity.data.RecentActivityResponse
@@ -22,6 +23,12 @@ interface WikiEduDashboardApi {
      ***/
     @GET
     suspend fun getCourseDetail(@Url url: String): CourseDetailResponse
+
+    /**
+     * This API is used to fetch campaign details and statistics.
+     ***/
+    @GET
+    suspend fun getCampaignDetail(@Url url: String): CampaignDetailsResponse
 
     /**
      * This API is used to fetch list of articles of a course.

--- a/app/src/main/java/org/wikiedufoundation/wikiedudashboard/di/repositoryModule.kt
+++ b/app/src/main/java/org/wikiedufoundation/wikiedudashboard/di/repositoryModule.kt
@@ -3,6 +3,8 @@ package org.wikiedufoundation.wikiedudashboard.di
 import org.koin.dsl.module
 import org.wikiedufoundation.wikiedudashboard.ui.campaign.repository.ActiveCampaignRepository
 import org.wikiedufoundation.wikiedudashboard.ui.campaign.repository.ActiveCampaignRepositoryImpl
+import org.wikiedufoundation.wikiedudashboard.ui.campaigndetails.home.repsoitory.CampaignDetailRepository
+import org.wikiedufoundation.wikiedudashboard.ui.campaigndetails.home.repsoitory.CampaignDetailRepositoryImpl
 import org.wikiedufoundation.wikiedudashboard.ui.coursedetail.articlesedited.repository.ArticlesEditedRepository
 import org.wikiedufoundation.wikiedudashboard.ui.coursedetail.articlesedited.repository.ArticlesEditedRepositoryImpl
 import org.wikiedufoundation.wikiedudashboard.ui.coursedetail.common.repository.CourseDetailRepository
@@ -36,4 +38,5 @@ val repositoryModule = module {
     single <CourseDetailRepository> { CourseDetailRepositoryImpl(get()) }
     single <ProfileRepository> { ProfileRepositoryImpl(get()) }
     single <MediaDetailsRepository> { MediaDetailsRepositoryImpl(get()) }
+    single <CampaignDetailRepository> { CampaignDetailRepositoryImpl(get()) }
 }

--- a/app/src/main/java/org/wikiedufoundation/wikiedudashboard/di/viewModelModule.kt
+++ b/app/src/main/java/org/wikiedufoundation/wikiedudashboard/di/viewModelModule.kt
@@ -3,6 +3,7 @@ package org.wikiedufoundation.wikiedudashboard.di
 import org.koin.androidx.viewmodel.dsl.viewModel
 import org.koin.dsl.module
 import org.wikiedufoundation.wikiedudashboard.ui.campaign.viewmodel.ActiveCampaignViewModel
+import org.wikiedufoundation.wikiedudashboard.ui.campaigndetails.home.viewmodel.CampaignHomeViewModel
 import org.wikiedufoundation.wikiedudashboard.ui.coursedetail.articlesedited.viewmodel.ArticlesEditedViewModel
 import org.wikiedufoundation.wikiedudashboard.ui.coursedetail.common.viewmodel.CourseDetailViewModel
 import org.wikiedufoundation.wikiedudashboard.ui.coursedetail.students.viewmodel.StudentsViewModel
@@ -27,4 +28,5 @@ val viewModelModule = module {
     viewModel { CourseDetailViewModel(get()) }
     viewModel { ProfileViewModel(get()) }
     viewModel { (cookies: String) -> MediaDetailsViewModel(get(), cookies) }
+    viewModel { CampaignHomeViewModel(get()) }
 }

--- a/app/src/main/java/org/wikiedufoundation/wikiedudashboard/ui/campaign/view/CampaignListFragment.kt
+++ b/app/src/main/java/org/wikiedufoundation/wikiedudashboard/ui/campaign/view/CampaignListFragment.kt
@@ -1,5 +1,6 @@
 package org.wikiedufoundation.wikiedudashboard.ui.campaign.view
 
+import android.content.Intent
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
@@ -15,6 +16,7 @@ import org.wikiedufoundation.wikiedudashboard.R
 import org.wikiedufoundation.wikiedudashboard.data.preferences.SharedPrefs
 import org.wikiedufoundation.wikiedudashboard.ui.adapters.CampaignListRecyclerAdapter
 import org.wikiedufoundation.wikiedudashboard.ui.campaign.viewmodel.ActiveCampaignViewModel
+import org.wikiedufoundation.wikiedudashboard.ui.campaigndetails.home.view.CampaignDetailsHomeActivity
 import org.wikiedufoundation.wikiedudashboard.util.filterOrEmptyList
 import timber.log.Timber
 import java.util.Locale
@@ -50,7 +52,7 @@ class CampaignListFragment : Fragment() {
         super.onViewCreated(view, savedInstanceState)
 
         campaignListRecyclerAdapter = CampaignListRecyclerAdapter(R.layout.item_rv_campaign_list) {
-            //                        openCourseDetail(it)
+            openCampaignDetail(it)
         }
         initializeRecyclerView()
         setData()
@@ -91,6 +93,13 @@ class CampaignListFragment : Fragment() {
             val message = it?.showMsg
             Toast.makeText(context, message, Toast.LENGTH_LONG).show()
         })
+    }
+
+    private fun openCampaignDetail(slug: String) {
+        val i = Intent(context, CampaignDetailsHomeActivity::class.java)
+        i.putExtra("url", slug)
+        i.putExtra("enrolled", false)
+        startActivity(i)
     }
 
     /**

--- a/app/src/main/java/org/wikiedufoundation/wikiedudashboard/ui/campaigndetails/article/view/ArticleFragment.kt
+++ b/app/src/main/java/org/wikiedufoundation/wikiedudashboard/ui/campaigndetails/article/view/ArticleFragment.kt
@@ -1,0 +1,34 @@
+package org.wikiedufoundation.wikiedudashboard.ui.campaigndetails.article.view
+
+import androidx.lifecycle.ViewModelProviders
+import android.os.Bundle
+import androidx.fragment.app.Fragment
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import org.wikiedufoundation.wikiedudashboard.R
+
+import org.wikiedufoundation.wikiedudashboard.ui.campaigndetails.article.viewmodel.ArticleViewModel
+
+class ArticleFragment : Fragment() {
+
+    companion object {
+        fun newInstance() = ArticleFragment()
+    }
+
+    private lateinit var viewModel: ArticleViewModel
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View? {
+        return inflater.inflate(R.layout.article_fragment, container, false)
+    }
+
+    override fun onActivityCreated(savedInstanceState: Bundle?) {
+        super.onActivityCreated(savedInstanceState)
+        viewModel = ViewModelProviders.of(this).get(ArticleViewModel::class.java)
+        // TODO: Use the ViewModel
+    }
+}

--- a/app/src/main/java/org/wikiedufoundation/wikiedudashboard/ui/campaigndetails/article/viewmodel/ArticleViewModel.kt
+++ b/app/src/main/java/org/wikiedufoundation/wikiedudashboard/ui/campaigndetails/article/viewmodel/ArticleViewModel.kt
@@ -1,0 +1,7 @@
+package org.wikiedufoundation.wikiedudashboard.ui.campaigndetails.article.viewmodel
+
+import androidx.lifecycle.ViewModel
+
+class ArticleViewModel : ViewModel() {
+    // TODO: Implement the ViewModel
+}

--- a/app/src/main/java/org/wikiedufoundation/wikiedudashboard/ui/campaigndetails/course/view/CourseFragment.kt
+++ b/app/src/main/java/org/wikiedufoundation/wikiedudashboard/ui/campaigndetails/course/view/CourseFragment.kt
@@ -1,0 +1,34 @@
+package org.wikiedufoundation.wikiedudashboard.ui.campaigndetails.course.view
+
+import androidx.lifecycle.ViewModelProviders
+import android.os.Bundle
+import androidx.fragment.app.Fragment
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import org.wikiedufoundation.wikiedudashboard.R
+
+import org.wikiedufoundation.wikiedudashboard.ui.campaigndetails.course.viewmodel.CourseViewModel
+
+class CourseFragment : Fragment() {
+
+    companion object {
+        fun newInstance() = CourseFragment()
+    }
+
+    private lateinit var viewModel: CourseViewModel
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View? {
+        return inflater.inflate(R.layout.course_fragment, container, false)
+    }
+
+    override fun onActivityCreated(savedInstanceState: Bundle?) {
+        super.onActivityCreated(savedInstanceState)
+        viewModel = ViewModelProviders.of(this).get(CourseViewModel::class.java)
+        // TODO: Use the ViewModel
+    }
+}

--- a/app/src/main/java/org/wikiedufoundation/wikiedudashboard/ui/campaigndetails/course/viewmodel/CourseViewModel.kt
+++ b/app/src/main/java/org/wikiedufoundation/wikiedudashboard/ui/campaigndetails/course/viewmodel/CourseViewModel.kt
@@ -1,0 +1,7 @@
+package org.wikiedufoundation.wikiedudashboard.ui.campaigndetails.course.viewmodel
+
+import androidx.lifecycle.ViewModel
+
+class CourseViewModel : ViewModel() {
+    // TODO: Implement the ViewModel
+}

--- a/app/src/main/java/org/wikiedufoundation/wikiedudashboard/ui/campaigndetails/home/data/CampaignDetails.kt
+++ b/app/src/main/java/org/wikiedufoundation/wikiedudashboard/ui/campaigndetails/home/data/CampaignDetails.kt
@@ -1,0 +1,22 @@
+package org.wikiedufoundation.wikiedudashboard.ui.campaigndetails.home.data
+
+import java.io.Serializable
+
+data class CampaignDetails(
+    val id: Int,
+    val title: String,
+    val slug: String,
+    val description: String,
+    val course_count: String,
+    val created_count: String,
+    val edited_count: String,
+    val word_count: String,
+    val reference_count: String,
+    val views_count: String,
+    val student_count: String,
+    val uplaod_count: String,
+    val creation_date: String,
+    val template_description: String,
+    val default_course_type: String,
+    val default_passcode: String
+) : Serializable

--- a/app/src/main/java/org/wikiedufoundation/wikiedudashboard/ui/campaigndetails/home/data/CampaignDetailsResponse.kt
+++ b/app/src/main/java/org/wikiedufoundation/wikiedudashboard/ui/campaigndetails/home/data/CampaignDetailsResponse.kt
@@ -1,0 +1,3 @@
+package org.wikiedufoundation.wikiedudashboard.ui.campaigndetails.home.data
+
+data class CampaignDetailsResponse(val campaign: CampaignDetails)

--- a/app/src/main/java/org/wikiedufoundation/wikiedudashboard/ui/campaigndetails/home/repsoitory/CampaignDetailRepository.kt
+++ b/app/src/main/java/org/wikiedufoundation/wikiedudashboard/ui/campaigndetails/home/repsoitory/CampaignDetailRepository.kt
@@ -1,0 +1,14 @@
+package org.wikiedufoundation.wikiedudashboard.ui.campaigndetails.home.repsoitory
+
+import org.wikiedufoundation.wikiedudashboard.ui.campaigndetails.home.data.CampaignDetails
+
+/**
+ *Declares CampaignDetailRepository interface
+ * */
+interface CampaignDetailRepository {
+
+    /**
+     *Creates a suspend function [requestCampaignDetails]
+     * */
+    suspend fun requestCampaignDetails(url: String): CampaignDetails
+}

--- a/app/src/main/java/org/wikiedufoundation/wikiedudashboard/ui/campaigndetails/home/repsoitory/CampaignDetailRepositoryImpl.kt
+++ b/app/src/main/java/org/wikiedufoundation/wikiedudashboard/ui/campaigndetails/home/repsoitory/CampaignDetailRepositoryImpl.kt
@@ -1,0 +1,25 @@
+package org.wikiedufoundation.wikiedudashboard.ui.campaigndetails.home.repsoitory
+
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import org.wikiedufoundation.wikiedudashboard.data.network.WikiEduDashboardApi
+import org.wikiedufoundation.wikiedudashboard.ui.campaigndetails.home.data.CampaignDetails
+import org.wikiedufoundation.wikiedudashboard.util.Urls
+
+/**
+ * Declares the api as a private property in the constructor.
+ * */
+class CampaignDetailRepositoryImpl(private val wikiEduDashboardApi: WikiEduDashboardApi) :
+        CampaignDetailRepository {
+
+    /** The suspend modifier tells the compiler that this must be called from a
+     *  coroutine or another suspend function.
+     **/
+    override suspend fun requestCampaignDetails(url: String): CampaignDetails =
+            withContext(Dispatchers.IO) {
+            val request = wikiEduDashboardApi
+                    .getCampaignDetail(Urls.SUB_URL_CAMPAIGN_DETAIL.format(url))
+            val campaignDetail = request.campaign
+            campaignDetail
+    }
+}

--- a/app/src/main/java/org/wikiedufoundation/wikiedudashboard/ui/campaigndetails/home/view/CampaignDetailActivity.kt
+++ b/app/src/main/java/org/wikiedufoundation/wikiedudashboard/ui/campaigndetails/home/view/CampaignDetailActivity.kt
@@ -1,0 +1,106 @@
+package org.wikiedufoundation.wikiedudashboard.ui.campaigndetails.home.view
+
+import android.content.Intent
+import android.os.Bundle
+import android.view.View
+import androidx.appcompat.app.AppCompatActivity
+import androidx.lifecycle.Observer
+import kotlinx.android.synthetic.main.activity_course_detail.*
+import org.koin.androidx.viewmodel.ext.android.viewModel
+import org.wikiedufoundation.wikiedudashboard.R
+import org.wikiedufoundation.wikiedudashboard.ui.campaigndetails.article.view.ArticleFragment
+import org.wikiedufoundation.wikiedudashboard.ui.campaigndetails.course.view.CourseFragment
+import org.wikiedufoundation.wikiedudashboard.ui.campaigndetails.home.viewmodel.CampaignHomeViewModel
+import org.wikiedufoundation.wikiedudashboard.ui.campaigndetails.student.view.StudentFragment
+import org.wikiedufoundation.wikiedudashboard.util.ViewPagerAdapter
+import org.wikiedufoundation.wikiedudashboard.util.showToast
+import timber.log.Timber
+
+class CampaignDetailActivity : AppCompatActivity() {
+
+    private var enrolled = false
+    private lateinit var url: String
+    private lateinit var campaignHomeFragment: CampaignHomeFragment
+    private val campaignDetailsViewModel by viewModel<CampaignHomeViewModel>()
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+
+        setContentView(R.layout.activity_campaign_detail)
+
+        url = intent.getStringExtra("url")
+        enrolled = intent.getBooleanExtra("enrolled", false)
+
+        val action = intent.action
+        val data = intent.dataString
+        if (Intent.ACTION_VIEW == action && data != null) {
+
+            url = data.substring(data.lastIndexOf("courses/") + 8)
+            val urlExists = url.contains("?enroll")
+            if (urlExists) {
+                url = url.lastIndexOf("?enroll").let { url.substring(0, it) }
+            }
+        }
+
+        url?.let { campaignDetailsViewModel.requestCampaignDetail(it) }
+
+        setData()
+        initializeProgressBar()
+        initializeToaster()
+        tabLayout.setupWithViewPager(viewPager)
+        toolbar.setNavigationOnClickListener { onBackPressed() }
+    }
+
+    /**
+     * Set course detail tabs
+     * ***/
+    private fun setTabs() {
+        val courseFragment = CourseFragment()
+        val bundle = Bundle()
+        bundle.putString("url", url)
+        courseFragment.arguments = bundle
+
+        val articleFragment = ArticleFragment()
+        val bundle2 = Bundle()
+        bundle2.putString("url", url)
+        articleFragment.arguments = bundle2
+
+        val studentFragment = StudentFragment()
+        val bundle3 = Bundle()
+        bundle3.putString("url", url)
+        studentFragment.arguments = bundle3
+
+        val fragmentList = listOf(campaignHomeFragment,
+                courseFragment,
+                articleFragment,
+                studentFragment)
+
+        val titleList = listOf("Home", "Courses", "Articles", "Students")
+
+        viewPager.apply {
+            adapter = ViewPagerAdapter(supportFragmentManager, fragmentList, titleList)
+        }
+    }
+
+    private fun setData() {
+        campaignDetailsViewModel.campaignDetail.observe(this, Observer {
+            Timber.d("hello  $it.title")
+            toolbar.title = it.title
+            campaignHomeFragment = CampaignHomeFragment.newInstance(it)
+            setTabs()
+        })
+    }
+
+    private fun initializeProgressBar() {
+        campaignDetailsViewModel.progressbar.observe(this, androidx.lifecycle.Observer {
+            progressBar.visibility = if (it) View.VISIBLE else View.GONE
+        })
+    }
+
+    private fun initializeToaster() {
+        campaignDetailsViewModel.showMsg.observe(this, androidx.lifecycle.Observer {
+            val message = it.showMsg
+            showToast(message)
+        })
+    }
+}

--- a/app/src/main/java/org/wikiedufoundation/wikiedudashboard/ui/campaigndetails/home/view/CampaignHomeFragment.kt
+++ b/app/src/main/java/org/wikiedufoundation/wikiedudashboard/ui/campaigndetails/home/view/CampaignHomeFragment.kt
@@ -1,0 +1,76 @@
+package org.wikiedufoundation.wikiedudashboard.ui.campaigndetails.home.view
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.fragment.app.Fragment
+import kotlinx.android.synthetic.main.campaign_home_fragment.*
+import org.wikiedufoundation.wikiedudashboard.R
+import org.wikiedufoundation.wikiedudashboard.ui.campaigndetails.home.data.CampaignDetails
+import org.wikiedufoundation.wikiedudashboard.ui.coursedetail.common.view.home.CourseHomeFragment
+import java.text.SimpleDateFormat
+import java.util.Locale
+
+class CampaignHomeFragment : Fragment() {
+
+    private var campaignDetail: CampaignDetails? = null
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View? =
+            inflater.inflate(R.layout.campaign_home_fragment, container, false)
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        arguments?.let {
+            campaignDetail = it.getSerializable(ARG_PARAM1) as CampaignDetails
+        }
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        setData()
+    }
+
+    private fun setData() {
+        textViewCountCourses.text = campaignDetail?.course_count
+        textViewCountArticlesCreated.text = campaignDetail?.created_count
+        textViewCountArticlesEdited.text = campaignDetail?.edited_count
+        textViewCountWordsAdded.text = campaignDetail?.word_count
+        textViewCountReferencesAdded.text = campaignDetail?.reference_count
+        textViewCountArticleViews.text = campaignDetail?.views_count
+        textViewCountstudents.text = campaignDetail?.student_count
+        textViewCountCommonsUploads.text = campaignDetail?.uplaod_count
+        textViewCampaignTitle.text = campaignDetail?.title
+        textViewCampaignDescription.text = campaignDetail?.description
+        textViewCreationDateDetail.text = campaignDetail?.creation_date
+    }
+
+    companion object {
+        private const val ARG_PARAM1 = "param1"
+
+        /**
+         * This method creates a new instance of [CourseHomeFragment]
+         */
+        fun newInstance(campaignDetail: CampaignDetails?) = CampaignHomeFragment().apply {
+            val args = Bundle()
+            args.putSerializable(ARG_PARAM1, campaignDetail)
+            this.arguments = args
+        }
+    }
+
+    /**
+     * This method converts date to readable format
+     * using the [SimpleDateFormat] class
+     */
+    fun readableDate(realDate: String?): CharSequence? {
+        val pattern = "EEE d MMM  yyyy"
+        val simpleDateFormat = SimpleDateFormat(pattern, Locale.getDefault())
+        val inputFormat = SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSX", Locale.getDefault())
+        val date = inputFormat.parse(realDate)
+        return simpleDateFormat.format(date)
+    }
+}

--- a/app/src/main/java/org/wikiedufoundation/wikiedudashboard/ui/campaigndetails/home/viewmodel/CampaignHomeViewModel.kt
+++ b/app/src/main/java/org/wikiedufoundation/wikiedudashboard/ui/campaigndetails/home/viewmodel/CampaignHomeViewModel.kt
@@ -1,0 +1,41 @@
+package org.wikiedufoundation.wikiedudashboard.ui.campaigndetails.home.viewmodel
+
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import kotlinx.coroutines.launch
+import org.wikiedufoundation.wikiedudashboard.ui.campaigndetails.home.data.CampaignDetails
+import org.wikiedufoundation.wikiedudashboard.ui.campaigndetails.home.repsoitory.CampaignDetailRepository
+import org.wikiedufoundation.wikiedudashboard.util.ShowMessage
+import java.io.IOException
+
+class CampaignHomeViewModel(private val campaignDetailRepository: CampaignDetailRepository) : ViewModel() {
+
+    private val _showMsg: MutableLiveData<ShowMessage> = MutableLiveData()
+    val showMsg: MutableLiveData<ShowMessage> get() = _showMsg
+    private val _progressbar = MutableLiveData<Boolean>()
+    val progressbar: LiveData<Boolean> get() = _progressbar
+    private val _campaignDetail: MutableLiveData<CampaignDetails> = MutableLiveData()
+    val campaignDetail: LiveData<CampaignDetails> get() = _campaignDetail
+
+    init {
+        _progressbar.postValue(true)
+    }
+
+    /**
+     * ViewModels have a coroutine scope based on their lifecycle called
+     *  viewModelScope which we can use here.
+     **/
+    fun requestCampaignDetail(url: String) {
+        viewModelScope.launch {
+            try {
+                _campaignDetail.postValue(campaignDetailRepository.requestCampaignDetails(url))
+                _progressbar.postValue(false)
+            } catch (io: IOException) {
+                _showMsg.postValue(ShowMessage("Unable to connect to server."))
+                _progressbar.postValue(false)
+            }
+        }
+    }
+}

--- a/app/src/main/java/org/wikiedufoundation/wikiedudashboard/ui/campaigndetails/student/view/StudentFragment.kt
+++ b/app/src/main/java/org/wikiedufoundation/wikiedudashboard/ui/campaigndetails/student/view/StudentFragment.kt
@@ -1,0 +1,33 @@
+package org.wikiedufoundation.wikiedudashboard.ui.campaigndetails.student.view
+
+import androidx.lifecycle.ViewModelProviders
+import android.os.Bundle
+import androidx.fragment.app.Fragment
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import org.wikiedufoundation.wikiedudashboard.R
+import org.wikiedufoundation.wikiedudashboard.ui.campaigndetails.student.viewmodel.StudentViewModel
+
+class StudentFragment : Fragment() {
+
+    companion object {
+        fun newInstance() = StudentFragment()
+    }
+
+    private lateinit var viewModel: StudentViewModel
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View? {
+        return inflater.inflate(R.layout.student_fragment, container, false)
+    }
+
+    override fun onActivityCreated(savedInstanceState: Bundle?) {
+        super.onActivityCreated(savedInstanceState)
+        viewModel = ViewModelProviders.of(this).get(StudentViewModel::class.java)
+        // TODO: Use the ViewModel
+    }
+}

--- a/app/src/main/java/org/wikiedufoundation/wikiedudashboard/ui/campaigndetails/student/viewmodel/StudentViewModel.kt
+++ b/app/src/main/java/org/wikiedufoundation/wikiedudashboard/ui/campaigndetails/student/viewmodel/StudentViewModel.kt
@@ -1,0 +1,7 @@
+package org.wikiedufoundation.wikiedudashboard.ui.campaigndetails.student.viewmodel
+
+import androidx.lifecycle.ViewModel
+
+class StudentViewModel : ViewModel() {
+    // TODO: Implement the ViewModel
+}

--- a/app/src/main/java/org/wikiedufoundation/wikiedudashboard/util/Urls.kt
+++ b/app/src/main/java/org/wikiedufoundation/wikiedudashboard/util/Urls.kt
@@ -13,6 +13,8 @@ object Urls {
     val SUB_URL_COURSE_RECENT = "courses/%s/revisions.json"
     val SUB_URL_COURSE_UPLOADS = "courses/%s/uploads.json"
     val PROFILE_DETAIL = BASE_URL + "users/%s/?format=json"
+    val SUB_URL_CAMPAIGN_DETAIL = "campaigns/%s.json"
+    val SUB_URL_CAMPAIGN_STUDENT = "campaigns/%s/users.json"
 
 //    Urls.BASE_URL + "users/" + username + "?format=json"
 }

--- a/app/src/main/res/layout/activity_campaign_detail.xml
+++ b/app/src/main/res/layout/activity_campaign_detail.xml
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    tools:context="org.wikiedufoundation.wikiedudashboard.ui.campaigndetails.home.view.CampaignDetailsHomeActivity">
+
+    <com.google.android.material.appbar.AppBarLayout
+        android:id="@+id/appBarLayout"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintStart_toStartOf="parent">
+
+        <androidx.appcompat.widget.Toolbar
+            android:id="@+id/toolbar"
+            android:layout_width="match_parent"
+            android:layout_height="?attr/actionBarSize"
+            app:navigationIcon="@drawable/ic_arrow_back_black_24dp"
+            app:title="@string/demo_course" />
+
+        <com.google.android.material.tabs.TabLayout
+            android:id="@+id/tabLayout"
+            android:layout_width="match_parent"
+            android:layout_height="?attr/actionBarSize"
+            android:layout_gravity="bottom"
+            android:background="@color/colorPrimary"
+            app:tabMode="scrollable"
+            app:tabSelectedTextColor="@color/colorAccent"
+            app:tabTextAppearance="@android:style/TextAppearance.Widget.TabWidget" />
+    </com.google.android.material.appbar.AppBarLayout>
+
+    <androidx.viewpager.widget.ViewPager
+        android:id="@+id/viewPager"
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/appBarLayout"
+        app:layout_constraintBottom_toBottomOf="parent"/>
+
+    <ProgressBar
+        android:id="@+id/progressBar"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_centerHorizontal="true"
+        android:layout_centerVertical="true"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintLeft_toLeftOf="parent"
+        app:layout_constraintRight_toRightOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/article_fragment.xml
+++ b/app/src/main/res/layout/article_fragment.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    tools:context="org.wikiedufoundation.wikiedudashboard.ui.campaigndetails.article.view.ArticleFragment">
+
+    <TextView
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:text="Hello" />
+
+</FrameLayout>

--- a/app/src/main/res/layout/campaign_home_fragment.xml
+++ b/app/src/main/res/layout/campaign_home_fragment.xml
@@ -1,0 +1,326 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    tools:context="org.wikiedufoundation.wikiedudashboard.ui.campaigndetails.home.view.CampaignHomeFragment">
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:background="@color/colorGrayBackground">
+
+        <TextView
+            android:id="@+id/textViewCountCourses"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="@dimen/padding_8dp"
+            android:layout_marginTop="@dimen/padding_8dp"
+            android:layout_marginEnd="@dimen/dimen_16dp"
+            android:gravity="center"
+            android:padding="@dimen/padding_8dp"
+            android:text="@string/_45"
+            android:textColor="@color/colorAccent"
+            android:textSize="@dimen/text_size_30sp"
+            app:layout_constraintEnd_toStartOf="@+id/textViewCountArticlesCreated"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent"
+            app:layout_constraintVertical_chainStyle="packed" />
+
+        <TextView
+            android:id="@+id/textViewCourses"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginEnd="@dimen/padding_16dp"
+            android:gravity="center"
+            android:padding="@dimen/padding_8dp"
+            android:text="@string/courses"
+            app:layout_constraintEnd_toEndOf="@id/textViewCountCourses"
+            app:layout_constraintStart_toStartOf="@id/textViewCountCourses"
+            app:layout_constraintTop_toBottomOf="@+id/textViewCountCourses" />
+
+
+        <TextView
+            android:id="@+id/textViewCountArticlesCreated"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="@dimen/padding_16dp"
+            android:layout_marginTop="@dimen/padding_8dp"
+            android:layout_marginEnd="@dimen/dimen_16dp"
+            android:gravity="center"
+            android:padding="@dimen/padding_8dp"
+            android:text="@string/_45"
+            android:textColor="@color/colorAccent"
+            android:textSize="@dimen/text_size_30sp"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toEndOf="@+id/textViewCourses"
+            app:layout_constraintTop_toTopOf="parent"
+            app:layout_constraintVertical_chainStyle="packed" />
+
+        <TextView
+            android:id="@+id/textViewArticlesCreated"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:gravity="center"
+            android:padding="@dimen/padding_8dp"
+            android:text="@string/articles_created"
+            app:layout_constraintEnd_toEndOf="@id/textViewCountArticlesCreated"
+            app:layout_constraintStart_toStartOf="@id/textViewCountArticlesCreated"
+            app:layout_constraintTop_toBottomOf="@+id/textViewCountArticlesCreated" />
+
+
+        <TextView
+            android:id="@+id/textViewCountArticlesEdited"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="@dimen/padding_8dp"
+            android:layout_marginLeft="@dimen/padding_8dp"
+            android:layout_marginTop="@dimen/padding_8dp"
+            android:layout_marginEnd="@dimen/dimen_8dp"
+            android:gravity="center"
+            android:padding="@dimen/padding_8dp"
+            android:text="@string/_45"
+            android:textColor="@color/colorAccent"
+            android:textSize="@dimen/text_size_30sp"
+            app:layout_constraintEnd_toEndOf="@+id/textViewCourses"
+            app:layout_constraintStart_toStartOf="@id/textViewCourses"
+            app:layout_constraintTop_toBottomOf="@id/textViewCourses" />
+
+        <TextView
+            android:id="@+id/textViewArticlesEdited"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="@dimen/padding_8dp"
+            android:layout_marginEnd="@dimen/padding_16dp"
+            android:gravity="center"
+            android:padding="@dimen/padding_8dp"
+            android:text="@string/articles_edited"
+            app:layout_constraintEnd_toEndOf="@id/textViewCountArticlesEdited"
+            app:layout_constraintStart_toStartOf="@id/textViewCountArticlesEdited"
+            app:layout_constraintTop_toBottomOf="@+id/textViewCountArticlesEdited" />
+
+        <TextView
+            android:id="@+id/textViewCountWordsAdded"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="@dimen/padding_16dp"
+            android:layout_marginTop="@dimen/padding_8dp"
+            android:layout_marginEnd="@dimen/dimen_16dp"
+            android:gravity="center"
+            android:padding="@dimen/padding_8dp"
+            android:text="@string/_45"
+            android:textColor="@color/colorAccent"
+            android:textSize="@dimen/text_size_30sp"
+            app:layout_constraintEnd_toEndOf="@id/textViewArticlesCreated"
+            app:layout_constraintStart_toStartOf="@+id/textViewArticlesCreated"
+            app:layout_constraintTop_toBottomOf="@id/textViewArticlesCreated" />
+
+        <TextView
+            android:id="@+id/textViewWordsAdded"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:gravity="center"
+            android:padding="@dimen/padding_8dp"
+            android:text="@string/words_added"
+            app:layout_constraintEnd_toEndOf="@id/textViewCountWordsAdded"
+            app:layout_constraintStart_toStartOf="@id/textViewCountWordsAdded"
+            app:layout_constraintTop_toBottomOf="@+id/textViewCountWordsAdded" />
+
+        <TextView
+            android:id="@+id/textViewCountReferencesAdded"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="@dimen/padding_8dp"
+            android:layout_marginLeft="@dimen/padding_8dp"
+            android:layout_marginTop="@dimen/padding_8dp"
+            android:layout_marginEnd="@dimen/dimen_16dp"
+            android:gravity="center"
+            android:padding="@dimen/padding_8dp"
+            android:text="@string/_45"
+            android:textColor="@color/colorAccent"
+            android:textSize="@dimen/text_size_30sp"
+            app:layout_constraintEnd_toEndOf="@+id/textViewArticlesEdited"
+            app:layout_constraintStart_toStartOf="@id/textViewArticlesEdited"
+            app:layout_constraintTop_toBottomOf="@id/textViewArticlesEdited" />
+
+        <TextView
+            android:id="@+id/textViewReferencesAdded"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="@dimen/padding_8dp"
+            android:layout_marginEnd="@dimen/padding_16dp"
+            android:gravity="center"
+            android:padding="@dimen/padding_8dp"
+            android:text="@string/references_added"
+            app:layout_constraintEnd_toEndOf="@id/textViewCountReferencesAdded"
+            app:layout_constraintStart_toStartOf="@id/textViewCountReferencesAdded"
+            app:layout_constraintTop_toBottomOf="@+id/textViewCountReferencesAdded" />
+
+        <TextView
+            android:id="@+id/textViewCountArticleViews"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="@dimen/padding_16dp"
+            android:layout_marginTop="@dimen/padding_8dp"
+            android:layout_marginEnd="@dimen/dimen_16dp"
+            android:gravity="center"
+            android:padding="@dimen/padding_8dp"
+            android:text="@string/_45"
+            android:textColor="@color/colorAccent"
+            android:textSize="@dimen/text_size_30sp"
+            app:layout_constraintEnd_toEndOf="@id/textViewWordsAdded"
+            app:layout_constraintStart_toStartOf="@+id/textViewWordsAdded"
+            app:layout_constraintTop_toBottomOf="@id/textViewWordsAdded" />
+
+        <TextView
+            android:id="@+id/textViewArticleViews"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:gravity="center"
+            android:padding="@dimen/padding_8dp"
+            android:text="@string/article_views"
+            app:layout_constraintEnd_toEndOf="@id/textViewCountArticleViews"
+            app:layout_constraintStart_toStartOf="@id/textViewCountArticleViews"
+            app:layout_constraintTop_toBottomOf="@+id/textViewCountArticleViews" />
+
+
+        <TextView
+            android:id="@+id/textViewCountstudents"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="@dimen/padding_16dp"
+            android:layout_marginLeft="@dimen/padding_8dp"
+            android:layout_marginTop="@dimen/padding_8dp"
+            android:layout_marginEnd="@dimen/dimen_16dp"
+            android:gravity="center"
+            android:padding="@dimen/padding_8dp"
+            android:text="@string/_45"
+            android:textColor="@color/colorAccent"
+            android:textSize="@dimen/text_size_30sp"
+            app:layout_constraintEnd_toEndOf="@id/textViewReferencesAdded"
+            app:layout_constraintStart_toStartOf="@+id/textViewReferencesAdded"
+            app:layout_constraintTop_toBottomOf="@id/textViewReferencesAdded" />
+
+        <TextView
+            android:id="@+id/textViewStudents"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="@dimen/padding_8dp"
+            android:gravity="center"
+            android:padding="@dimen/padding_8dp"
+            android:text="@string/students"
+            app:layout_constraintEnd_toEndOf="@id/textViewCountstudents"
+            app:layout_constraintStart_toStartOf="@id/textViewCountstudents"
+            app:layout_constraintTop_toBottomOf="@+id/textViewCountstudents" />
+
+
+        <TextView
+            android:id="@+id/textViewCountCommonsUploads"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="@dimen/padding_16dp"
+            android:layout_marginTop="@dimen/padding_8dp"
+            android:layout_marginEnd="@dimen/dimen_16dp"
+            android:gravity="center"
+            android:padding="@dimen/padding_8dp"
+            android:text="@string/_45"
+            android:textColor="@color/colorAccent"
+            android:textSize="@dimen/text_size_30sp"
+            app:layout_constraintEnd_toEndOf="@id/textViewArticleViews"
+            app:layout_constraintStart_toStartOf="@+id/textViewArticleViews"
+            app:layout_constraintTop_toBottomOf="@id/textViewArticleViews" />
+
+        <TextView
+            android:id="@+id/textViewCommonUploads"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:gravity="center"
+            android:padding="@dimen/padding_8dp"
+            android:text="@string/commons_upload"
+            app:layout_constraintEnd_toEndOf="@id/textViewCountCommonsUploads"
+            app:layout_constraintStart_toStartOf="@id/textViewCountCommonsUploads"
+            app:layout_constraintTop_toBottomOf="@+id/textViewCountCommonsUploads" />
+
+        <androidx.cardview.widget.CardView
+            android:id="@+id/cvCampaignDescription"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            app:layout_constraintEnd_toEndOf="@id/textViewCommonUploads"
+            app:layout_constraintStart_toStartOf="@+id/textViewCommonUploads"
+            app:layout_constraintTop_toBottomOf="@id/textViewCommonUploads">
+
+            <TextView
+                android:id="@+id/textViewCampaignTitle"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="@dimen/padding_8dp"
+                android:padding="@dimen/padding_8dp"
+                android:text="@string/campaign_title"
+                android:textColor="@color/colorAccent"
+                android:textSize="@dimen/text_size_24sp"
+                android:textStyle="bold" />
+
+            <TextView
+                android:id="@+id/textViewCampaignDescription"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="@dimen/padding_8dp"
+                android:layout_marginTop="@dimen/padding_48dp"
+                android:padding="@dimen/padding_8dp"
+                android:text="@string/campaign_title"
+                android:textAlignment="textStart" />
+
+        </androidx.cardview.widget.CardView>
+
+        <androidx.cardview.widget.CardView
+            android:id="@+id/cvCampaignDetail"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            app:layout_constraintEnd_toEndOf="@id/textViewCommonUploads"
+            app:layout_constraintStart_toStartOf="@+id/textViewCommonUploads"
+            app:layout_constraintTop_toBottomOf="@id/cvCampaignDescription">
+
+            <androidx.constraintlayout.widget.ConstraintLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content">
+
+                <TextView
+                    android:id="@+id/textViewCampaignDetails"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginStart="@dimen/padding_8dp"
+                    android:padding="@dimen/padding_8dp"
+                    android:text="@string/campaign_detail"
+                    android:textColor="@color/colorAccent"
+                    android:textSize="@dimen/text_size_24sp"
+                    android:textStyle="bold"
+                    app:layout_constraintLeft_toLeftOf="parent"
+                    app:layout_constraintTop_toTopOf="parent" />
+
+                <TextView
+                    android:id="@+id/textViewCreationDate"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:padding="@dimen/padding_8dp"
+                    android:text="@string/creation_date"
+                    android:textAlignment="textStart"
+                    android:textStyle="bold"
+                    app:layout_constraintLeft_toLeftOf="@id/textViewCampaignDetails"
+                    app:layout_constraintTop_toBottomOf="@id/textViewCampaignDetails" />
+
+                <TextView
+                    android:id="@+id/textViewCreationDateDetail"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginStart="@dimen/padding_8dp"
+                    android:padding="@dimen/padding_8dp"
+                    android:text="@string/date_edited"
+                    android:textAlignment="textStart"
+                    app:layout_constraintLeft_toRightOf="@id/textViewCreationDate"
+                    app:layout_constraintTop_toBottomOf="@id/textViewCampaignDetails" />
+            </androidx.constraintlayout.widget.ConstraintLayout>
+        </androidx.cardview.widget.CardView>
+    </androidx.constraintlayout.widget.ConstraintLayout>
+
+</ScrollView>

--- a/app/src/main/res/layout/course_fragment.xml
+++ b/app/src/main/res/layout/course_fragment.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    tools:context="org.wikiedufoundation.wikiedudashboard.ui.campaigndetails.course.view.CourseFragment">
+
+    <TextView
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:text="Hello" />
+
+</FrameLayout>

--- a/app/src/main/res/layout/fragment_explore_course_list.xml
+++ b/app/src/main/res/layout/fragment_explore_course_list.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.constraintlayout.widget.ConstraintLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/relativeLayout"

--- a/app/src/main/res/layout/student_fragment.xml
+++ b/app/src/main/res/layout/student_fragment.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    tools:context="org.wikiedufoundation.wikiedudashboard.ui.campaigndetails.student.view.StudentFragment">
+
+    <TextView
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:text="Hello" />
+
+</FrameLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -92,5 +92,11 @@
     <string name="wiki_education_dashboard_singleLine">Wiki Education Dashboard</string>
     <string name="total_impact_made_by_students">Total impact made by %s\'s student</string>
     <string name="total_impact_made_as_student">Total impact made as %s as a student</string>
+    <string name="Courses">Courses</string>
+    <string name="courses">Courses</string>
+    <string name="students">Students</string>
+    <string name="campaign_title">Campaign Title</string>
+    <string name="campaign_detail">Details</string>
+    <string name="creation_date">Creation Date:</string>
 
 </resources>


### PR DESCRIPTION

## What this PR does
Fixes #346

**Describe the purpose of this pull request and note the issue it addresses**
- Created all four tabs for home- course- articles, and students
- Implemented the home tab using the MVVM pattern
- Created data class and consumed the available campaign details API to display details of the campaign on the home tab

## Open questions and concerns
- Given available API on the once the campaign, the item is clicked to the detail home tab you can only see the title and description. Those are the only data available as of now.

##TODO
- Campaign details data class and the campaign home fragment would need to be modified later on once more data are provided from the server-side
