### PR TITLE
Fixes #387: Fix for gradle distribution url and spotless plugin

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -15,7 +15,7 @@ buildscript {
 }
 
 plugins {
-    id "com.diffplug.gradle.spotless" version "5.1.1"
+    id "com.diffplug.spotless" version "5.1.1"
     id "org.jlleitschuh.gradle.ktlint" version "9.3.0"
 }
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.1.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.2-all.zip


### PR DESCRIPTION
Fixes #387 

Changed  the gradle distribution version and the spotless gradle plugin which were resulting in travis build faliure
